### PR TITLE
[Feat/#5] : 뉴스 크롤링, 기사 분야 분류, 퀴즈 생성 기능 구현 및 Clova AI 연결

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,6 +26,20 @@ jobs:
         echo "${{ secrets.APPLICATION_SECRET }}" > ./src/main/resources/application-secret.yml
       shell: bash
 
+    - name: Generate news-categorize-prompt.txt
+      run: |
+        cat <<EOF > ./src/main/resources/news-categorize-prompt.txt
+        ${{ secrets.NEWS_CATEGORIZE_PROMPT }}
+        EOF
+      shell: bash
+
+    - name: Generate quiz-generation-prompt.txt
+      run: |
+        cat <<EOF > ./src/main/resources/quiz-generate-prompt.txt
+        ${{ secrets.QUIZ_GENERATE_PROMPT }}
+        EOF
+      shell: bash
+
     - name: 빌드
       run: |
           chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 .DS_Store
 src/main/resources/application-secret.yml
+src/main/resources/news-categorize-prompt.txt

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 .DS_Store
 src/main/resources/application-secret.yml
 src/main/resources/news-categorize-prompt.txt
+src/main/resources/quiz-generate-prompt.txt

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // Jsoup
+    implementation 'org.jsoup:jsoup:1.15.3'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
     // Jsoup
     implementation 'org.jsoup:jsoup:1.15.3'
+
+    // WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/newquiz/NewquizApplication.java
+++ b/src/main/java/com/example/newquiz/NewquizApplication.java
@@ -3,9 +3,11 @@ package com.example.newquiz;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class NewquizApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/newquiz/common/status/ErrorStatus.java
+++ b/src/main/java/com/example/newquiz/common/status/ErrorStatus.java
@@ -22,6 +22,11 @@ public enum ErrorStatus implements BaseErrorStatus {
     NOT_FOUND_USER_BY_USERNAME(HttpStatus.NOT_FOUND, 404, "해당하는 닉네임의 사용자를 찾을 수 없습니다."),
     NOT_FOUND_USER_BY_USER_ID(HttpStatus.NOT_FOUND, 404, "해당하는 사용자를 찾을 수 없습니다."),
     ALREADY_REGISTERED_USER(HttpStatus.BAD_REQUEST, 400, "이미 가입된 사용자입니다."),
+
+    // AI 관련 에러
+    AI_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "AI 서버와의 통신 중 클라이언트 오류가 발생했습니다."),
+    AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "AI 서버와의 통신 중 서버 오류가 발생했습니다."),
+    INVALID_AI_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, 500, "AI 서버로부터 올바르지 않은 응답을 받았습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/newquiz/common/util/ClovaUtil.java
+++ b/src/main/java/com/example/newquiz/common/util/ClovaUtil.java
@@ -1,0 +1,59 @@
+package com.example.newquiz.common.util;
+
+import com.example.newquiz.common.exception.GeneralException;
+import com.example.newquiz.common.status.ErrorStatus;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class ClovaUtil {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebClient webClient = WebClient.create();
+
+    @Value("${ncp.chat.host}")
+    private String chatHost;
+
+    @Value("${ncp.chat.api-key}")
+    private String API_KEY;
+
+    public String postWebClient(Object clovaRequest) {
+        return webClient.post()
+                .uri(chatHost)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + API_KEY)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(clovaRequest)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+                    log.error("클라이언트 오류 발생: 상태 코드 - {}", clientResponse.statusCode());
+                    return clientResponse.bodyToMono(String.class)
+                            .map(errorBody -> new GeneralException(ErrorStatus.AI_CLIENT_ERROR));
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
+                    log.error("서버 오류 발생: 상태 코드 - {}", clientResponse.statusCode());
+                    return clientResponse.bodyToMono(String.class)
+                            .map(errorBody -> new GeneralException(ErrorStatus.AI_SERVER_ERROR));
+                })
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    public String parseContentFromResponse(String responseBody) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode messageContent = root.path("result").path("message").path("content");
+            return messageContent.asText();
+        } catch (Exception e) {
+            log.error("응답 파싱 실패", e);
+            throw new GeneralException(ErrorStatus.INVALID_AI_RESPONSE);
+        }
+    }
+}
+

--- a/src/main/java/com/example/newquiz/common/util/ResourceLoader.java
+++ b/src/main/java/com/example/newquiz/common/util/ResourceLoader.java
@@ -1,0 +1,19 @@
+package com.example.newquiz.common.util;
+
+import com.example.newquiz.common.exception.GeneralException;
+import com.example.newquiz.common.status.ErrorStatus;
+import org.springframework.core.io.ClassPathResource;
+import java.nio.charset.StandardCharsets;
+
+public class ResourceLoader {
+
+    public static String getResourceContent(String resourcePath) {
+        try {
+            var resource = new ClassPathResource(resourcePath);
+            return new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.NOT_FOUND);
+        }
+    }
+}
+

--- a/src/main/java/com/example/newquiz/controller/NewsCrawlerController.java
+++ b/src/main/java/com/example/newquiz/controller/NewsCrawlerController.java
@@ -1,0 +1,19 @@
+package com.example.newquiz.controller;
+
+import com.example.newquiz.service.NewsCrawlerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/news")
+@RequiredArgsConstructor
+public class NewsCrawlerController {
+
+    private final NewsCrawlerService newsCrawlerService;
+
+    @PostMapping("/crawl")
+    public String crawlNews() {
+        newsCrawlerService.crawlNews();
+        return "테스트 크롤링 완료!";
+    }
+}

--- a/src/main/java/com/example/newquiz/controller/NewsTestController.java
+++ b/src/main/java/com/example/newquiz/controller/NewsTestController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/test")
 @RequiredArgsConstructor
-public class NewsCrawlerController {
+public class NewsTestController {
 
     private final NewsCrawlerService newsCrawlerService;
 

--- a/src/main/java/com/example/newquiz/controller/NewsTestController.java
+++ b/src/main/java/com/example/newquiz/controller/NewsTestController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/news")
+@RequestMapping("/api/test")
 @RequiredArgsConstructor
 public class NewsCrawlerController {
 

--- a/src/main/java/com/example/newquiz/domain/MeaningQuiz.java
+++ b/src/main/java/com/example/newquiz/domain/MeaningQuiz.java
@@ -21,7 +21,7 @@ public class MeaningQuiz extends BaseEntity {
     private Long quizId;
 
     @Column(name = "answer", nullable = false)
-    private String answer;
+    private Integer answer;
 
     @Column(name = "option1", nullable = false)
     private String option1;

--- a/src/main/java/com/example/newquiz/domain/News.java
+++ b/src/main/java/com/example/newquiz/domain/News.java
@@ -29,7 +29,17 @@ public class News extends BaseEntity {
     @Column(name = "source", nullable = false)
     private String source;
 
-    @Column(name = "category", nullable = false)
+    @Setter
+    @Column(name = "category")
     @Enumerated(EnumType.STRING)
     private NewsCategory category;
+
+    @Builder
+    public static News toEntity(String title, LocalDate date, String source) {
+        return News.builder()
+                .title(title)
+                .date(date)
+                .source(source)
+                .build();
+    }
 }

--- a/src/main/java/com/example/newquiz/domain/Paragraph.java
+++ b/src/main/java/com/example/newquiz/domain/Paragraph.java
@@ -20,8 +20,8 @@ public class Paragraph extends BaseEntity {
     @Column(name = "news_id", nullable = false)
     private Long newsId;
 
-    @Column(name = "order", nullable = false)
-    private Integer order;
+    @Column(name = "content_order", nullable = false)
+    private Integer content_order;
 
     @Column(name = "content", nullable = false)
     private String content;

--- a/src/main/java/com/example/newquiz/domain/Paragraph.java
+++ b/src/main/java/com/example/newquiz/domain/Paragraph.java
@@ -23,6 +23,7 @@ public class Paragraph extends BaseEntity {
     @Column(name = "content_order", nullable = false)
     private Integer content_order;
 
-    @Column(name = "content", nullable = false)
+    @Lob
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
 }

--- a/src/main/java/com/example/newquiz/domain/Paragraph.java
+++ b/src/main/java/com/example/newquiz/domain/Paragraph.java
@@ -21,9 +21,18 @@ public class Paragraph extends BaseEntity {
     private Long newsId;
 
     @Column(name = "content_order", nullable = false)
-    private Integer content_order;
+    private Integer contentOrder;
 
     @Lob
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
+
+    @Builder
+    public static Paragraph toEntity(Long newsId, Integer content_order, String content) {
+        return Paragraph.builder()
+                .newsId(newsId)
+                .contentOrder(content_order)
+                .content(content)
+                .build();
+    }
 }

--- a/src/main/java/com/example/newquiz/domain/Quiz.java
+++ b/src/main/java/com/example/newquiz/domain/Quiz.java
@@ -28,12 +28,15 @@ public class Quiz extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private QuizType type;
 
+    @Setter
     @Column(name = "sysnonym_quiz_id")
     private Long synonymQuizId;
 
+    @Setter
     @Column(name = "meaning_quiz_id")
     private Long meaningQuizId;
 
+    @Setter
     @Column(name = "content_quiz_id")
     private Long contentQuizId;
 }

--- a/src/main/java/com/example/newquiz/dto/request/NewsCategorizeClovaRequest.java
+++ b/src/main/java/com/example/newquiz/dto/request/NewsCategorizeClovaRequest.java
@@ -1,0 +1,39 @@
+package com.example.newquiz.dto.request;
+
+import com.example.newquiz.common.util.ResourceLoader;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class NewsCategorizeClovaRequest {
+    private static final String SYSTEM_CONTENT = ResourceLoader.getResourceContent("news-categorize-prompt.txt");
+
+    private List<Map<String, String>> messages;
+    private final double topP = 0.8;
+    private final int topK = 0;
+    private final int maxTokens = 700;
+    private final double temperature = 0.5;
+    private final double repeatPenalty = 5.0;
+    private final boolean includeAiFilters = true;
+    private final int seed = 0;
+
+    public NewsCategorizeClovaRequest(List<Map<String, String>> messages) {
+        this.messages = messages;
+    }
+
+
+    public static NewsCategorizeClovaRequest createNewsCategorizeRequest(List<String> newsContents) {
+        // newsContents를 하나의 String으로 합치기 (문단 간 개행 추가)
+        String combinedNewsContent = String.join("\n", newsContents);
+
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(Map.of("role", "system", "content", SYSTEM_CONTENT));
+        messages.add(Map.of("role", "user", "content", combinedNewsContent));
+
+        return new NewsCategorizeClovaRequest(messages);
+    }
+
+}

--- a/src/main/java/com/example/newquiz/dto/request/QuizCreateClovaRequest.java
+++ b/src/main/java/com/example/newquiz/dto/request/QuizCreateClovaRequest.java
@@ -1,0 +1,45 @@
+package com.example.newquiz.dto.request;
+
+import com.example.newquiz.common.util.ResourceLoader;
+import com.example.newquiz.domain.Paragraph;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+public class QuizCreateClovaRequest {
+    private static final String SYSTEM_CONTENT = ResourceLoader.getResourceContent("quiz-generate-prompt.txt");
+
+    private List<Map<String, String>> messages;
+    private final double topP = 0.8;
+    private final int topK = 0;
+    private final int maxTokens = 700;
+    private final double temperature = 0.5;
+    private final double repeatPenalty = 5.0;
+    private final boolean includeAiFilters = true;
+    private final int seed = 0;
+
+    public QuizCreateClovaRequest(List<Map<String, String>> messages) {
+        this.messages = messages;
+    }
+
+    public static QuizCreateClovaRequest createQuizCreateClovaRequest(List<Paragraph> paragraphs) {
+        List<Map<String, String>> messages = new ArrayList<>();
+
+        // 시스템 메시지 추가
+        messages.add(Map.of("role", "system", "content", SYSTEM_CONTENT));
+
+        String formattedContent = paragraphs.stream()
+                .map(p -> String.format("[ParagraphID: %d]\n%s", p.getParagraphId(), p.getContent()))
+                .collect(Collectors.joining("\n\n")); // 문단 간 개행 추가
+
+
+        // 사용자 메시지 추가
+        messages.add(Map.of("role", "user", "content", formattedContent));
+
+        return new QuizCreateClovaRequest(messages);
+    }
+}

--- a/src/main/java/com/example/newquiz/dto/response/NewsCategorizeResponse.java
+++ b/src/main/java/com/example/newquiz/dto/response/NewsCategorizeResponse.java
@@ -1,0 +1,14 @@
+package com.example.newquiz.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NewsCategorizeResponse {
+    @JsonProperty("category")
+    private String category;
+}

--- a/src/main/java/com/example/newquiz/dto/response/QuizCreateResponse.java
+++ b/src/main/java/com/example/newquiz/dto/response/QuizCreateResponse.java
@@ -1,0 +1,32 @@
+package com.example.newquiz.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizCreateResponse {
+
+    @JsonProperty("questions")
+    private List<Question> questions;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Question {
+        private String type;
+        private String selectedWord;
+        private String sourceSentence;
+        private List<String> options;
+        private String answer;
+        private String explanation;
+        private String example;
+        private int sourceParagraphId;
+        private String question; // 내용일치 유형만 사용
+    }
+}

--- a/src/main/java/com/example/newquiz/repository/ParagraphRepository.java
+++ b/src/main/java/com/example/newquiz/repository/ParagraphRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface ParagraphRepository extends JpaRepository<Paragraph, Long> {
     List<Paragraph> findByNewsIdOrderByContentOrderAsc(Long newsId);
+    void deleteByNewsId(Long newsId);
 }

--- a/src/main/java/com/example/newquiz/repository/ParagraphRepository.java
+++ b/src/main/java/com/example/newquiz/repository/ParagraphRepository.java
@@ -3,5 +3,8 @@ package com.example.newquiz.repository;
 import com.example.newquiz.domain.Paragraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ParagraphRepository extends JpaRepository<Paragraph, Long> {
+    List<Paragraph> findByNewsIdOrderByContentOrderAsc(Long newsId);
 }

--- a/src/main/java/com/example/newquiz/repository/QuizRepository.java
+++ b/src/main/java/com/example/newquiz/repository/QuizRepository.java
@@ -4,4 +4,5 @@ import com.example.newquiz.domain.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
+    Boolean existsByNewsId(Long newsId);
 }

--- a/src/main/java/com/example/newquiz/service/NewsCategorizeService.java
+++ b/src/main/java/com/example/newquiz/service/NewsCategorizeService.java
@@ -1,0 +1,79 @@
+package com.example.newquiz.service;
+
+import com.example.newquiz.common.exception.GeneralException;
+import com.example.newquiz.common.status.ErrorStatus;
+import com.example.newquiz.common.util.ClovaUtil;
+import com.example.newquiz.domain.Paragraph;
+import com.example.newquiz.domain.enums.NewsCategory;
+import com.example.newquiz.dto.request.NewsCategorizeClovaRequest;
+import com.example.newquiz.dto.response.NewsCategorizeResponse;
+import com.example.newquiz.repository.NewsRepository;
+import com.example.newquiz.repository.ParagraphRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NewsCategorizeService {
+
+    private final ClovaUtil clovaUtil;
+    private final NewsRepository newsRepository;
+    private final ParagraphRepository paragraphRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional
+    public void categorizeNews(Long newsId) {
+        try {
+            // 뉴스 문단 가져오기
+            List<String> newsContents = paragraphRepository.findByNewsIdOrderByContentOrderAsc(newsId)
+                    .stream()
+                    .map(Paragraph::getContent)
+                    .collect(Collectors.toList());
+
+            // Clova API 요청
+            NewsCategorizeClovaRequest clovaRequest = NewsCategorizeClovaRequest.createNewsCategorizeRequest(newsContents);
+            String response = clovaUtil.postWebClient(clovaRequest);
+
+            // AI 응답 파싱
+            NewsCategorizeResponse newsCategorizeResponse = parseNewsCategorizeResponse(clovaUtil.parseContentFromResponse(response));
+
+            // 카테고리 매핑 후 저장
+            NewsCategory category = switch (newsCategorizeResponse.getCategory()) {
+                case "정치" -> NewsCategory.POLITICS;
+                case "경제" -> NewsCategory.ECONOMY;
+                case "사회" -> NewsCategory.SOCIETY;
+                default -> NewsCategory.ETC;
+            };
+
+            updateNewsCategory(newsId, category);
+
+        } catch (Exception e) {
+            // 예외 발생 시 분류 실패한 뉴스만 건너뛰고 전체 크롤링은 계속 진행
+            log.error("🚨 뉴스 ID {} 카테고리 분류 실패: {}", newsId, e.getMessage(), e);
+        }
+    }
+
+    private NewsCategorizeResponse parseNewsCategorizeResponse(String aiResponse) {
+        try {
+            return objectMapper.readValue(aiResponse, NewsCategorizeResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorStatus.INVALID_AI_RESPONSE);
+        }
+    }
+
+    private void updateNewsCategory(Long newsId, NewsCategory category) {
+        newsRepository.findById(newsId)
+                .ifPresent(news -> {
+                    news.setCategory(category);
+                    newsRepository.save(news);
+                });
+    }
+}

--- a/src/main/java/com/example/newquiz/service/NewsCrawlerService.java
+++ b/src/main/java/com/example/newquiz/service/NewsCrawlerService.java
@@ -1,0 +1,106 @@
+package com.example.newquiz.service;
+
+import com.example.newquiz.domain.News;
+import com.example.newquiz.domain.Paragraph;
+import com.example.newquiz.repository.NewsRepository;
+import com.example.newquiz.repository.ParagraphRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.select.Elements;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NewsCrawlerService {
+
+    private final NewsCategorizeService newsCategorizeService;
+    private final NewsRepository newsRepository;
+    private final ParagraphRepository paragraphRepository;
+
+    private static final String BASE_URL = "https://news.naver.com/opinion/editorial";
+        private static final List<String> ALLOWED_SOURCES = Arrays.asList(
+            "강원일보", "경기일보", "국민일보", "국제신문", "농민신문", "매일경제",
+            "서울경제", "서울신문", "세계일보", "이데일리", "중앙일보", "파이낸셜뉴스",
+            "한국경제", "한국일보", "헤럴드경제"
+    );
+
+    @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시에 실행
+    public void crawlNews() {
+        try {
+            log.info("📰 뉴스 크롤링 시작...");
+            Document doc = Jsoup.connect(BASE_URL).get();
+            Elements newsLinks = doc.select("div.opinion_calendar_content ul.opinion_editorial_list li.opinion_editorial_item a.link");
+
+            for (Element link : newsLinks) {
+                String articleUrl = link.attr("href");
+                crawlArticle(articleUrl);
+            }
+        } catch (Exception e) {
+            log.error("❌ 뉴스 크롤링 실패", e);
+        }
+    }
+
+    @Transactional
+    protected void crawlArticle(String url) {
+        try {
+            Document doc = Jsoup.connect(url).get();
+            String title = doc.select("h2.media_end_head_headline").text();
+            String source = doc.select("a.media_end_head_top_logo img").attr("alt");
+            String dateText = doc.select("span.media_end_head_info_datestamp_time").text();
+            Element articleElement = doc.selectFirst("article#dic_area");
+
+            if (!ALLOWED_SOURCES.contains(source)) {
+                // 허용되지 않은 언론사인 경우 크롤링 건너뛰기
+                log.warn("🚫 허용되지 않은 언론사: {}", source);
+                return;
+            }
+
+            // 날짜 포맷 변환
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd. a h:mm", Locale.KOREAN);
+            LocalDateTime dateTime = LocalDateTime.parse(dateText, formatter);
+            LocalDate parsedDate = dateTime.toLocalDate();
+
+            // 뉴스 저장
+            News news = News.toEntity(title, parsedDate, source);
+            news = newsRepository.save(news);
+
+            // 문단 저장 (br 태그 기준)
+            if (articleElement != null) {
+                List<TextNode> textNodes = articleElement.textNodes();
+                int order = 1;
+
+                for (TextNode node : textNodes) {
+                    String paragraph = node.text().trim();
+                    if (!paragraph.isEmpty()) {
+                        Paragraph para = Paragraph.toEntity(news.getNewsId(), order++, paragraph);
+                        paragraphRepository.save(para);
+                    }
+                }
+            }
+
+            // 뉴스 저장 후 자동으로 AI 카테고리 분류 실행 (에러 발생 시 건너뛰기)
+            try {
+                newsCategorizeService.categorizeNews(news.getNewsId());
+            } catch (Exception e) {
+                log.error("🚨 AI 카테고리 분류 실패 (뉴스 ID: {}), 원인: {}", news.getNewsId(), e.getMessage());
+            }
+
+        } catch (Exception e) {
+            log.error("❌ 기사 크롤링 실패: {}", url, e);
+        }
+    }
+}

--- a/src/main/java/com/example/newquiz/service/NewsCrawlerService.java
+++ b/src/main/java/com/example/newquiz/service/NewsCrawlerService.java
@@ -40,7 +40,7 @@ public class NewsCrawlerService {
             "한국경제", "한국일보", "헤럴드경제"
     );
 
-    @Scheduled(cron = "0 0 23 * * ?") // 매일 23시에 실행
+    @Scheduled(cron = "0 0 6 * * ?") // 매일 23시에 실행 -> 6시로 테스트 중
     public void crawlNews() {
         try {
             log.info("📰 뉴스 크롤링 시작...");

--- a/src/main/java/com/example/newquiz/service/NewsCrawlerService.java
+++ b/src/main/java/com/example/newquiz/service/NewsCrawlerService.java
@@ -4,6 +4,7 @@ import com.example.newquiz.domain.News;
 import com.example.newquiz.domain.Paragraph;
 import com.example.newquiz.repository.NewsRepository;
 import com.example.newquiz.repository.ParagraphRepository;
+import com.example.newquiz.repository.QuizRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -20,37 +21,40 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class NewsCrawlerService {
 
+    private final QuizCreateService quizCreateService;
+    private final QuizRepository quizRepository;
     private final NewsCategorizeService newsCategorizeService;
     private final NewsRepository newsRepository;
     private final ParagraphRepository paragraphRepository;
 
     private static final String BASE_URL = "https://news.naver.com/opinion/editorial";
-        private static final List<String> ALLOWED_SOURCES = Arrays.asList(
+    private static final List<String> ALLOWED_SOURCES = Arrays.asList(
             "강원일보", "경기일보", "국민일보", "국제신문", "농민신문", "매일경제",
             "서울경제", "서울신문", "세계일보", "이데일리", "중앙일보", "파이낸셜뉴스",
             "한국경제", "한국일보", "헤럴드경제"
     );
 
-    @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시에 실행
+    @Scheduled(cron = "0 0 23 * * ?") // 매일 23시에 실행
     public void crawlNews() {
         try {
             log.info("📰 뉴스 크롤링 시작...");
             Document doc = Jsoup.connect(BASE_URL).get();
             Elements newsLinks = doc.select("div.opinion_calendar_content ul.opinion_editorial_list li.opinion_editorial_item a.link");
-
+            log.info("🔗 크롤링된 뉴스 링크 수: {}", newsLinks.size());
+            int i = 0;
             for (Element link : newsLinks) {
+                log.info("크롤링 시도 횟수 : {}", i++);
                 String articleUrl = link.attr("href");
                 crawlArticle(articleUrl);
             }
         } catch (Exception e) {
-            log.error("❌ 뉴스 크롤링 실패", e);
+            log.error("❌ 뉴스 크롤링 실패 원인 : {}", e.getMessage());
         }
     }
 
@@ -60,47 +64,86 @@ public class NewsCrawlerService {
             Document doc = Jsoup.connect(url).get();
             String title = doc.select("h2.media_end_head_headline").text();
             String source = doc.select("a.media_end_head_top_logo img").attr("alt");
-            String dateText = doc.select("span.media_end_head_info_datestamp_time").text();
+            String dateText = doc.select("span.media_end_head_info_datestamp_time").attr("data-date-time");
             Element articleElement = doc.selectFirst("article#dic_area");
 
             if (!ALLOWED_SOURCES.contains(source)) {
-                // 허용되지 않은 언론사인 경우 크롤링 건너뛰기
                 log.warn("🚫 허용되지 않은 언론사: {}", source);
                 return;
             }
 
-            // 날짜 포맷 변환
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd. a h:mm", Locale.KOREAN);
-            LocalDateTime dateTime = LocalDateTime.parse(dateText, formatter);
-            LocalDate parsedDate = dateTime.toLocalDate();
-
-            // 뉴스 저장
-            News news = News.toEntity(title, parsedDate, source);
-            news = newsRepository.save(news);
-
-            // 문단 저장 (br 태그 기준)
-            if (articleElement != null) {
-                List<TextNode> textNodes = articleElement.textNodes();
-                int order = 1;
-
-                for (TextNode node : textNodes) {
-                    String paragraph = node.text().trim();
-                    if (!paragraph.isEmpty()) {
-                        Paragraph para = Paragraph.toEntity(news.getNewsId(), order++, paragraph);
-                        paragraphRepository.save(para);
-                    }
-                }
-            }
-
-            // 뉴스 저장 후 자동으로 AI 카테고리 분류 실행 (에러 발생 시 건너뛰기)
-            try {
-                newsCategorizeService.categorizeNews(news.getNewsId());
-            } catch (Exception e) {
-                log.error("🚨 AI 카테고리 분류 실패 (뉴스 ID: {}), 원인: {}", news.getNewsId(), e.getMessage());
+            LocalDate parsedDate = parseDate(dateText);
+            Long newsId = saveNewsWithParagraphs(title, parsedDate, source, articleElement);
+            if(newsId != null) {
+                handlePostProcessing(newsId);
             }
 
         } catch (Exception e) {
-            log.error("❌ 기사 크롤링 실패: {}", url, e);
+            log.error("❌ 기사 크롤링 실패 원인 : {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 날짜 문자열을 LocalDate로 변환
+     */
+    private LocalDate parseDate(String dateText) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        LocalDateTime dateTime = LocalDateTime.parse(dateText, formatter);
+        return dateTime.toLocalDate();
+    }
+
+    /**
+     * 뉴스 및 문단 저장
+     */
+    private Long saveNewsWithParagraphs(String title, LocalDate date, String source, Element articleElement) {
+        try {
+            News news = News.toEntity(title, date, source);
+            news = newsRepository.save(news);
+            saveParagraphs(news, articleElement);
+            return news.getNewsId();
+
+        } catch (Exception e) {
+            log.error("🚨 뉴스 저장 실패 원인 : {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 문단 저장
+     */
+    private void saveParagraphs(News news, Element articleElement) {
+        List<TextNode> textNodes = articleElement.textNodes();
+        int order = 1;
+
+        for (TextNode node : textNodes) {
+            String paragraph = node.text().trim();
+            if (!paragraph.isEmpty()) {
+                Paragraph para = Paragraph.toEntity(news.getNewsId(), order++, paragraph);
+                paragraphRepository.save(para);
+            }
+        }
+    }
+
+    /**
+     * AI 분류 및 퀴즈 생성 처리
+     */
+    private void handlePostProcessing(Long newsId) {
+        try {
+            newsCategorizeService.categorizeNews(newsId);
+        } catch (Exception e) {
+            log.error("🚨 AI 카테고리 분류 실패 원인: {}", e.getMessage());
+            newsRepository.deleteById(newsId);
+            paragraphRepository.deleteByNewsId(newsId);
+            return;
+        }
+
+        try {
+            quizCreateService.createQuiz(newsId);
+        } catch (Exception e) {
+            log.error("🚨 퀴즈 생성 실패 원인: {}", e.getMessage());
+            newsRepository.deleteById(newsId);
+            paragraphRepository.deleteByNewsId(newsId);
+            return;
         }
     }
 }

--- a/src/main/java/com/example/newquiz/service/QuizCreateService.java
+++ b/src/main/java/com/example/newquiz/service/QuizCreateService.java
@@ -1,0 +1,145 @@
+package com.example.newquiz.service;
+
+import com.example.newquiz.common.util.ClovaUtil;
+import com.example.newquiz.domain.*;
+import com.example.newquiz.domain.enums.QuizType;
+import com.example.newquiz.dto.request.QuizCreateClovaRequest;
+import com.example.newquiz.dto.response.QuizCreateResponse;
+import com.example.newquiz.repository.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QuizCreateService {
+
+    private final ClovaUtil clovaUtil;
+    private final ParagraphRepository paragraphRepository;
+    private final QuizRepository quizRepository;
+    private final SynonymQuizRepository synonymQuizRepository;
+    private final MeaningQuizRepository meaningQuizRepository;
+    private final ContentQuizRepository contentQuizRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional
+    public void createQuiz(Long newsId) {
+        List<Paragraph> paragraphs = paragraphRepository.findByNewsIdOrderByContentOrderAsc(newsId);
+        if (paragraphs.isEmpty()) {
+            log.warn("뉴스 ID {}에 대한 문단이 없습니다.", newsId);
+            return;
+        }
+
+        // Clova AI 요청 및 응답 파싱
+        QuizCreateClovaRequest request = QuizCreateClovaRequest.createQuizCreateClovaRequest(paragraphs);
+        QuizCreateResponse response = parseQuizResponse(request);
+        if (response == null) return;
+
+        // 퀴즈 저장
+        List<Quiz> quizzes = createQuizFromResponse(response, newsId);
+        quizRepository.saveAll(quizzes);
+        log.info("뉴스 ID {}에 대한 퀴즈 {}개 생성 완료", newsId, quizzes.size());
+    }
+
+    /**
+     * Clova AI로부터 퀴즈 생성 요청을 보내고 응답을 파싱하는 메서드
+     */
+    private QuizCreateResponse parseQuizResponse(QuizCreateClovaRequest request) {
+        try {
+            String responseJson = clovaUtil.postWebClient(request);
+            return objectMapper.readValue(clovaUtil.parseContentFromResponse(responseJson), QuizCreateResponse.class);
+        } catch (Exception e) {
+            log.error("퀴즈 생성 응답 파싱 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Clova AI 응답 데이터를 바탕으로 Quiz 엔티티 생성
+     */
+    private List<Quiz> createQuizFromResponse(QuizCreateResponse response, Long newsId) {
+        List<Quiz> quizzes = new ArrayList<>();
+
+        for (QuizCreateResponse.Question question : response.getQuestions()) {
+            QuizType quizType = QuizType.getQuizType(question.getType());
+
+            Quiz quiz = quizRepository.save(
+                    Quiz.builder()
+                            .newsId(newsId)
+                            .paragraphId(Long.valueOf(question.getSourceParagraphId()))
+                            .type(quizType)
+                            .build()
+            );
+
+            saveQuizByType(quiz, question, quizType);
+            quizzes.add(quiz);
+        }
+        return quizzes;
+    }
+
+    /**
+     * 퀴즈 타입에 따라 적절한 엔티티 저장
+     */
+    private void saveQuizByType(Quiz quiz, QuizCreateResponse.Question question, QuizType quizType) {
+        switch (quizType) {
+            case SYNONYM:
+                SynonymQuiz synonymQuiz = synonymQuizRepository.save(
+                        SynonymQuiz.builder()
+                                .quizId(quiz.getQuizId())
+                                .answer(getAnswerIndex(question.getOptions(), question.getAnswer()))
+                                .option1(question.getOptions().get(0))
+                                .option2(question.getOptions().get(1))
+                                .option3(question.getOptions().get(2))
+                                .option4(question.getOptions().get(3))
+                                .explanation(question.getExplanation())
+                                .sourceSentence(question.getSourceSentence())
+                                .example(question.getExample())
+                                .build()
+                );
+                quiz.setSynonymQuizId(synonymQuiz.getSynonymQuizId());
+                break;
+
+            case MEANING:
+                MeaningQuiz meaningQuiz = meaningQuizRepository.save(
+                        MeaningQuiz.builder()
+                                .quizId(quiz.getQuizId())
+                                .answer(getAnswerIndex(question.getOptions(), question.getAnswer()))
+                                .option1(question.getOptions().get(0))
+                                .option2(question.getOptions().get(1))
+                                .option3(question.getOptions().get(2))
+                                .option4(question.getOptions().get(3))
+                                .explanation(question.getExplanation())
+                                .sourceSentence(question.getSourceSentence())
+                                .word(question.getSelectedWord())
+                                .example(question.getExample())
+                                .build()
+                );
+                quiz.setMeaningQuizId(meaningQuiz.getMeaningQuizId());
+                break;
+
+            case CONTENT:
+                ContentQuiz contentQuiz = contentQuizRepository.save(
+                        ContentQuiz.builder()
+                                .quizId(quiz.getQuizId())
+                                .answer(Boolean.parseBoolean(question.getAnswer()))
+                                .explanation(question.getExplanation())
+                                .question(question.getQuestion())
+                                .build()
+                );
+                quiz.setContentQuizId(contentQuiz.getContentQuizId());
+                break;
+        }
+    }
+
+    /**
+     * 정답이 어떤 옵션인지 인덱스를 찾아 반환 (1-based index)
+     */
+    private int getAnswerIndex(List<String> options, String answer) {
+        return options.indexOf(answer) + 1;
+    }
+}


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #5 

### 💡 작업내용
- 뉴스 기사 크롤링 코드 작성 -> 현재 오전 6시로 자동 크롤링 서버 테스트 중
- Clova AI 연결해서 기사 분야 분류 및 퀴즈/해설 생성 기능 구현 완료
- 현재는 AI가 퀴즈나 분야 분류에서 오류를 내면 뉴스 기사 자체를 삭제하게 구현 (추후 삭제 안하고 재요청하는 방식으로나 리팩 예정)

### 📸 스크린샷(선택)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
