### PR TITLE
[feat] : 분야별 기사 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newquiz/common/status/SuccessStatus.java
+++ b/src/main/java/com/example/newquiz/common/status/SuccessStatus.java
@@ -16,7 +16,11 @@ public enum SuccessStatus implements BaseSuccessStatus {
     USER_REGISTER_SUCCESS(HttpStatus.CREATED, 201, "회원가입에 성공하였습니다."),
 
     // 토큰 관련 성공
-    TOKEN_REISSUE_SUCCESS(HttpStatus.OK, 200, "토큰 재발급에 성공하였습니다."),;
+    TOKEN_REISSUE_SUCCESS(HttpStatus.OK, 200, "토큰 재발급에 성공하였습니다."),
+
+    // 뉴스 관련 성공
+    NEWS_LIST_SUCCESS(HttpStatus.OK, 200, "분야별 기사 목록 조회 성공입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/newquiz/controller/NewsController.java
+++ b/src/main/java/com/example/newquiz/controller/NewsController.java
@@ -1,0 +1,32 @@
+package com.example.newquiz.controller;
+
+import com.example.newquiz.auth.dto.CustomUserDetails;
+import com.example.newquiz.common.response.ApiResponse;
+import com.example.newquiz.common.status.SuccessStatus;
+import com.example.newquiz.dto.response.NewsResponse;
+import com.example.newquiz.service.NewsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/news")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<NewsResponse.NewsListDto>> getNewsList(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("category") String category
+    ) {
+        NewsResponse.NewsListDto response = newsService.getNewsList(userDetails.getUserId(), category);
+        return ApiResponse.success(SuccessStatus.NEWS_LIST_SUCCESS, response);
+    }
+
+}

--- a/src/main/java/com/example/newquiz/dto/converter/NewsConverter.java
+++ b/src/main/java/com/example/newquiz/dto/converter/NewsConverter.java
@@ -1,0 +1,24 @@
+package com.example.newquiz.dto.converter;
+
+import com.example.newquiz.domain.News;
+import com.example.newquiz.dto.response.NewsResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NewsConverter {
+    public static NewsResponse.NewsListDto toNewsListDto(List<News> newsList, String category) {
+        return NewsResponse.NewsListDto.builder()
+                .selectedCategory(category)
+                .newsCount(newsList.size())
+                .news(newsList.stream()
+                        .map(news -> NewsResponse.NewsDto.builder()
+                                .newsId(news.getNewsId())
+                                .title(news.getTitle())
+                                .date(news.getDate())
+                                .source(news.getSource())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/example/newquiz/dto/response/NewsResponse.java
+++ b/src/main/java/com/example/newquiz/dto/response/NewsResponse.java
@@ -1,0 +1,30 @@
+package com.example.newquiz.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class NewsResponse {
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class NewsListDto {
+        private String selectedCategory;
+        private int newsCount;
+        private List<NewsDto> news;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class NewsDto {
+        private Long newsId;
+        private String title;
+        private LocalDate date;
+        private String source;
+    }
+}

--- a/src/main/java/com/example/newquiz/repository/CompletedNewsRepository.java
+++ b/src/main/java/com/example/newquiz/repository/CompletedNewsRepository.java
@@ -3,5 +3,8 @@ package com.example.newquiz.repository;
 import com.example.newquiz.domain.CompletedNews;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CompletedNewsRepository extends JpaRepository<CompletedNews, Long> {
+    List<CompletedNews> findByUserId(Long userId);
 }

--- a/src/main/java/com/example/newquiz/repository/NewsRepository.java
+++ b/src/main/java/com/example/newquiz/repository/NewsRepository.java
@@ -1,8 +1,14 @@
 package com.example.newquiz.repository;
 
 import com.example.newquiz.domain.News;
+import com.example.newquiz.domain.enums.NewsCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface NewsRepository extends JpaRepository<News, Long> {
+    @Query("SELECT n FROM News n WHERE n.category = :category ORDER BY n.date DESC LIMIT 20")
+    List<News> findByCategory(NewsCategory category);
 }
 

--- a/src/main/java/com/example/newquiz/service/NewsService.java
+++ b/src/main/java/com/example/newquiz/service/NewsService.java
@@ -1,0 +1,37 @@
+package com.example.newquiz.service;
+
+import com.example.newquiz.domain.CompletedNews;
+import com.example.newquiz.domain.News;
+import com.example.newquiz.domain.enums.NewsCategory;
+import com.example.newquiz.dto.converter.NewsConverter;
+import com.example.newquiz.dto.response.NewsResponse;
+import com.example.newquiz.repository.CompletedNewsRepository;
+import com.example.newquiz.repository.NewsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+    private final NewsRepository newsRepository;
+    private final CompletedNewsRepository completedNewsRepository;
+
+    public NewsResponse.NewsListDto getNewsList(Long userId, String category) {
+        log.info("getNewsList userId: {}, category: {}", userId, category);
+
+        // 이미 퀴즈를 푼 뉴스는 제외
+        List<CompletedNews> completedNews = completedNewsRepository.findByUserId(userId);
+
+        // 뉴스 카테고리에 해당하는 뉴스 리스트를 가져옴
+        List<News> newsList = newsRepository.findByCategory(NewsCategory.getNewsCategory(category));
+
+        // 이미 퀴즈를 푼 뉴스는 제외
+        newsList.removeIf(news -> completedNews.stream().anyMatch(completed -> completed.getNewsId().equals(news.getNewsId())));
+
+        return NewsConverter.toNewsListDto(newsList, category);
+    }
+}


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #9 

### 💡 작업내용
- 분야별 기사 조회 기능 구현
- 이미 퀴즈를 푼 기사는 제외

### 📸 스크린샷(선택)
<img width="624" alt="image" src="https://github.com/user-attachments/assets/082b33cf-f935-4ede-8c89-2f8fe582bd62" />


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
