### PR TITLE
[Feat/#21] : 홈화면 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newquiz/common/status/SuccessStatus.java
+++ b/src/main/java/com/example/newquiz/common/status/SuccessStatus.java
@@ -14,6 +14,7 @@ public enum SuccessStatus implements BaseSuccessStatus {
 
     // 회원 관련 성공
     USER_REGISTER_SUCCESS(HttpStatus.CREATED, 201, "회원가입에 성공하였습니다."),
+    GET_HOME_INFO_SUCCESS(HttpStatus.OK, 200, "홈 화면 정보 조회 성공입니다."),
 
     // 토큰 관련 성공
     TOKEN_REISSUE_SUCCESS(HttpStatus.OK, 200, "토큰 재발급에 성공하였습니다."),

--- a/src/main/java/com/example/newquiz/controller/HomeController.java
+++ b/src/main/java/com/example/newquiz/controller/HomeController.java
@@ -1,0 +1,28 @@
+package com.example.newquiz.controller;
+
+import com.example.newquiz.auth.dto.CustomUserDetails;
+import com.example.newquiz.common.response.ApiResponse;
+import com.example.newquiz.common.status.SuccessStatus;
+import com.example.newquiz.dto.response.UserResponse;
+import com.example.newquiz.service.HomeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/home")
+public class HomeController {
+    private final HomeService homeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<UserResponse.HomeInfoDto>> getHomeInfo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        UserResponse.HomeInfoDto homeInfo = homeService.getHomeInfo(customUserDetails.getUserId());
+        return ApiResponse.success(SuccessStatus.GET_HOME_INFO_SUCCESS, homeInfo);
+    }
+}

--- a/src/main/java/com/example/newquiz/dto/response/UserResponse.java
+++ b/src/main/java/com/example/newquiz/dto/response/UserResponse.java
@@ -4,6 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
+import java.util.Calendar;
+import java.util.List;
+
 public class UserResponse {
 
     @Data
@@ -21,6 +25,16 @@ public class UserResponse {
     @AllArgsConstructor
     public static class NickNameCheckDto {
         private Boolean isDuplicate;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class HomeInfoDto {
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private Integer learningDays;
+        private Integer maxLearningDays;
     }
 
 }

--- a/src/main/java/com/example/newquiz/repository/CompletedNewsRepository.java
+++ b/src/main/java/com/example/newquiz/repository/CompletedNewsRepository.java
@@ -11,4 +11,6 @@ public interface CompletedNewsRepository extends JpaRepository<CompletedNews, Lo
     CompletedNews findByUserIdAndNewsId(Long userId, Long newsId);
 
     List<CompletedNews> findByUserIdOrderByCreatedAtDesc(Long userId);
+    List<CompletedNews> findByUserIdAndIsCompletedTrueOrderByUpdatedAtDesc(Long userId);
+
 }

--- a/src/main/java/com/example/newquiz/service/HomeService.java
+++ b/src/main/java/com/example/newquiz/service/HomeService.java
@@ -1,0 +1,87 @@
+package com.example.newquiz.service;
+
+import com.example.newquiz.common.exception.GeneralException;
+import com.example.newquiz.common.status.ErrorStatus;
+import com.example.newquiz.domain.CompletedNews;
+import com.example.newquiz.domain.User;
+import com.example.newquiz.dto.response.UserResponse;
+import com.example.newquiz.repository.CompletedNewsRepository;
+import com.example.newquiz.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+    private final UserRepository userRepository;
+    private final CompletedNewsRepository completedNewsRepository;
+
+    public UserResponse.HomeInfoDto getHomeInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_USER_BY_USER_ID));
+
+        // 연속 학습한 날짜 범위 계산
+        List<LocalDate> calendar = calculateConsecutiveLearningDays(userId);
+        int learningDays = calendar == null ? 0 : calculateLearningDays(calendar.get(0), calendar.get(1));
+
+        return UserResponse.HomeInfoDto.builder()
+                .startDate(calendar == null ? null : calendar.get(0))
+                .endDate(calendar == null ? null : calendar.get(1))
+                .learningDays(learningDays)
+                .maxLearningDays(user.getMaxLearningDays())
+                .build();
+    }
+
+    /**
+     * 연속 학습한 날짜 범위를 계산
+     */
+    private List<LocalDate> calculateConsecutiveLearningDays(Long userId) {
+        List<CompletedNews> completedNewsList = completedNewsRepository.findByUserIdAndIsCompletedTrueOrderByUpdatedAtDesc(userId);
+
+        if (completedNewsList.isEmpty()) {
+            return null; // 학습이 없으면 null 반환
+        }
+
+        LocalDate today = LocalDate.now();
+        YearMonth currentMonth = YearMonth.from(today);
+
+        // 현재 월에 학습한 기록이 있는지 확인
+        boolean hasLearningThisMonth = completedNewsList.stream()
+                .map(news -> news.getUpdatedAt().toLocalDate())
+                .anyMatch(date -> YearMonth.from(date).equals(currentMonth));
+
+        if (!hasLearningThisMonth) {
+            return null; // 이번 달 학습 기록이 없으면 null 반환
+        }
+
+        // 오늘 학습했는지 확인
+        Optional<LocalDate> latestStudyDate = completedNewsList.stream()
+                .map(news -> news.getUpdatedAt().toLocalDate())
+                .filter(date -> date.equals(today))
+                .findFirst();
+
+        LocalDate current = latestStudyDate.orElse(today.minusDays(1)); // 오늘 학습 안 했으면 어제부터 시작
+        LocalDate startDate = current;
+
+        for (CompletedNews news : completedNewsList) {
+            LocalDate newsDate = news.getUpdatedAt().toLocalDate();
+            if (newsDate.equals(current) || newsDate.equals(current.minusDays(1))) {
+                startDate = newsDate;
+                current = newsDate.minusDays(1);
+            } else {
+                break; // 연속되지 않는 날짜가 나오면 종료
+            }
+        }
+
+        return List.of(startDate, today);
+    }
+
+    private int calculateLearningDays(LocalDate startDate, LocalDate endDate) {
+        return (int) startDate.until(endDate).getDays() + 1;
+    }
+}


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #21 

### 💡 작업내용
- 홈 화면에 학습 캘린더, 연속 학습 일수, 최대 학습 일수 정보 조회 기능 구현

### 📸 스크린샷(선택)
<img width="326" alt="image" src="https://github.com/user-attachments/assets/0c78e6bb-599d-4704-a308-ee94745ee969" />


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
