### PR TITLE
[Feat/#25] : 오답노트 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/newquiz/common/status/SuccessStatus.java
+++ b/src/main/java/com/example/newquiz/common/status/SuccessStatus.java
@@ -32,6 +32,7 @@ public enum SuccessStatus implements BaseSuccessStatus {
     // 퀴즈 관련 성공
     GET_QUIZ_INFO_SUCCESS(HttpStatus.OK, 200, "퀴즈를 성공적으로 조회했습니다."),
     SAVE_QUIZ_RESULT_SUCCESS(HttpStatus.CREATED, 201, "퀴즈 정답 제출 성공입니다."),
+    NOTE_LIST_SUCCESS(HttpStatus.OK, 200, "오답 노트 목록 조회 성공입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/newquiz/common/util/JwtFilter.java
+++ b/src/main/java/com/example/newquiz/common/util/JwtFilter.java
@@ -64,7 +64,7 @@ public class JwtFilter extends OncePerRequestFilter {
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        String jsonResponse = String.format("{\"isSuccess\": \"false\", \"code\": \"401\", \"message\": \"%s\"}", e.getMessage());
+        String jsonResponse = String.format("{\"isSuccess\": \"false\", \"code\": \"0401\", \"message\": \"%s\"}", e.getMessage());
         response.getWriter().write(jsonResponse);
     }
 

--- a/src/main/java/com/example/newquiz/controller/NoteController.java
+++ b/src/main/java/com/example/newquiz/controller/NoteController.java
@@ -1,0 +1,31 @@
+package com.example.newquiz.controller;
+
+import com.example.newquiz.auth.dto.CustomUserDetails;
+import com.example.newquiz.common.response.ApiResponse;
+import com.example.newquiz.common.status.SuccessStatus;
+import com.example.newquiz.domain.enums.QuizType;
+import com.example.newquiz.dto.response.NoteResponse;
+import com.example.newquiz.service.NoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/note")
+public class NoteController {
+    private final NoteService noteService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<NoteResponse.NoteListDto>> getNoteList(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("type") String type
+    ) {
+        NoteResponse.NoteListDto response = noteService.getNoteList(userDetails.getUserId(), QuizType.getQuizType(type));
+        return ApiResponse.success(SuccessStatus.NOTE_LIST_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/example/newquiz/domain/QuizResult.java
+++ b/src/main/java/com/example/newquiz/domain/QuizResult.java
@@ -30,6 +30,10 @@ public class QuizResult extends BaseEntity {
     @Column(name = "is_correct", nullable = false)
     private Boolean isCorrect;
 
+    @Setter
+    @Column(name = "is_checked")
+    private Boolean isChecked;
+
     @Builder
     public static QuizResult toEntity(Long userId, QuizRequest.ResultDto resultDto) {
         return QuizResult.builder()

--- a/src/main/java/com/example/newquiz/dto/response/NoteDto.java
+++ b/src/main/java/com/example/newquiz/dto/response/NoteDto.java
@@ -1,0 +1,23 @@
+package com.example.newquiz.dto.response;
+
+import com.example.newquiz.domain.enums.NewsCategory;
+import com.example.newquiz.domain.enums.QuizType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoteDto {
+    private Long quizResultId;
+    private NewsCategory category;
+    private String title;
+    private LocalDate date;
+    private QuizType type;
+    private Boolean isChecked;
+}

--- a/src/main/java/com/example/newquiz/dto/response/NoteResponse.java
+++ b/src/main/java/com/example/newquiz/dto/response/NoteResponse.java
@@ -1,0 +1,18 @@
+package com.example.newquiz.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class NoteResponse {
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NoteListDto {
+        List<NoteDto> notes;
+    }
+}

--- a/src/main/java/com/example/newquiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/example/newquiz/repository/QuizResultRepository.java
@@ -1,10 +1,40 @@
 package com.example.newquiz.repository;
 
 import com.example.newquiz.domain.QuizResult;
+import com.example.newquiz.domain.enums.QuizType;
+import com.example.newquiz.dto.response.NoteDto;
+import com.example.newquiz.dto.response.NoteResponse;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
     boolean existsByUserIdAndQuizIdAndIsCorrect(Long userId, Long quizId, Boolean isCorrect);
     void deleteByUserId(Long userId);
+    @Query("""
+    SELECT new com.example.newquiz.dto.response.NoteDto(
+        qr.quizResultId, 
+        n.category, 
+        n.title, 
+        n.date, 
+        q.type, 
+        COALESCE(qr.isChecked, false)
+    )
+    FROM QuizResult qr
+    JOIN Quiz q ON qr.quizId = q.quizId
+    JOIN News n ON q.newsId = n.newsId
+    JOIN CompletedNews cn ON n.newsId = cn.newsId AND cn.userId = :userId
+    WHERE qr.userId = :userId
+    AND q.type = :quizType
+    AND qr.isCorrect = false
+    AND cn.isCompleted = true
+    ORDER BY n.date DESC
+""")
+    List<NoteDto> findIncorrectNotesByUserIdAndType(
+            @Param("userId") Long userId,
+            @Param("quizType") QuizType quizType
+    );
+
 }

--- a/src/main/java/com/example/newquiz/service/NoteService.java
+++ b/src/main/java/com/example/newquiz/service/NoteService.java
@@ -1,0 +1,23 @@
+package com.example.newquiz.service;
+
+import com.example.newquiz.domain.enums.QuizType;
+import com.example.newquiz.dto.response.NoteDto;
+import com.example.newquiz.dto.response.NoteResponse;
+import com.example.newquiz.repository.QuizResultRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoteService {
+    private final QuizResultRepository quizResultRepository;
+
+    public NoteResponse.NoteListDto getNoteList(Long userId, QuizType quizType) {
+        List<NoteDto> notes = quizResultRepository.findIncorrectNotesByUserIdAndType(userId, quizType);
+        return new NoteResponse.NoteListDto(notes);
+    }
+}


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #25 

### 💡 작업내용
- 사용자의 오답인 퀴즈의 뉴스 정보 조회
- [4.5] API 명세서 작성

### 📸 스크린샷(선택)
<img width="583" alt="image" src="https://github.com/user-attachments/assets/f9e77acc-9c44-4c3b-85a2-b0364e585fa0" />


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
