### PR TITLE
[Feat/#27] : 뉴스 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/newquiz/common/status/SuccessStatus.java
+++ b/src/main/java/com/example/newquiz/common/status/SuccessStatus.java
@@ -28,6 +28,7 @@ public enum SuccessStatus implements BaseSuccessStatus {
     NEWS_DETAIL_SUCCESS(HttpStatus.OK, 200, "기사 원문 조회 성공입니다."),
     SAVE_SUMMARY_SUCCESS(HttpStatus.CREATED, 201, "요약 제출 및 AI 피드백 받기 성공입니다."),
     SEND_LEVEL_FEEDBACK_SUCCESS(HttpStatus.CREATED, 201, "AI 난이도 조사 제출이 성공되었습니다."),
+    DELETE_NEWS_SUCCESS(HttpStatus.NO_CONTENT, 204, "기사 삭제 성공입니다."),
 
     // 퀴즈 관련 성공
     GET_QUIZ_INFO_SUCCESS(HttpStatus.OK, 200, "퀴즈를 성공적으로 조회했습니다."),

--- a/src/main/java/com/example/newquiz/controller/NewsController.java
+++ b/src/main/java/com/example/newquiz/controller/NewsController.java
@@ -57,4 +57,12 @@ public class NewsController {
         return ApiResponse.success(SuccessStatus.SEND_LEVEL_FEEDBACK_SUCCESS);
     }
 
+    @DeleteMapping("/{newsId}")
+    public ResponseEntity<ApiResponse<String>> deleteNews(
+            @PathVariable Long newsId
+    ) {
+        newsService.deleteNews(newsId);
+        return ApiResponse.success(SuccessStatus.DELETE_NEWS_SUCCESS);
+    }
+
 }

--- a/src/main/java/com/example/newquiz/repository/CompletedNewsRepository.java
+++ b/src/main/java/com/example/newquiz/repository/CompletedNewsRepository.java
@@ -12,4 +12,6 @@ public interface CompletedNewsRepository extends JpaRepository<CompletedNews, Lo
     void deleteByUserId(Long userId);
     List<CompletedNews> findByUserIdAndIsCompletedTrueOrderByUpdatedAtDesc(Long userId);
 
+    List<CompletedNews> findAllByNewsId(Long newsId);
+
 }

--- a/src/main/java/com/example/newquiz/service/NewsService.java
+++ b/src/main/java/com/example/newquiz/service/NewsService.java
@@ -171,14 +171,26 @@ public class NewsService {
         List<Paragraph> paragraphs = paragraphRepository.findByNewsId(newsId);
         List<CompletedNews> completedNews = completedNewsRepository.findAllByNewsId(newsId);
 
-        synonymQuizRepository.deleteAllById(quizzes.stream().map(Quiz::getSynonymQuizId).toList());
-        meaningQuizRepository.deleteAllById(quizzes.stream().map(Quiz::getMeaningQuizId).toList());
-        contentQuizRepository.deleteAllById(quizzes.stream().map(Quiz::getContentQuizId).toList());
+        deleteQuizzesByType(quizzes, Quiz::getSynonymQuizId, synonymQuizRepository);
+        deleteQuizzesByType(quizzes, Quiz::getMeaningQuizId, meaningQuizRepository);
+        deleteQuizzesByType(quizzes, Quiz::getContentQuizId, contentQuizRepository);
+
         paragraphRepository.deleteAll(paragraphs);
         completedNewsRepository.deleteAll(completedNews);
         quizRepository.deleteAll(quizzes);
         newsRepository.delete(news);
     }
 
+    private <T > void deleteQuizzesByType
+            (List < Quiz > quizzes, java.util.function.Function < Quiz, Long > quizIdExtractor, JpaRepository < T, Long > repository)
+    {
+        List<Long> ids = quizzes.stream()
+                .map(quizIdExtractor)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        if (!ids.isEmpty()) {
+            repository.deleteAllById(ids);
+        }
+    }
 
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #27 

### 💡 작업내용
- 뉴스 + 퀴즈 + 관련 타입 퀴즈 + 완료된 뉴스 + 퀴즈 결과 모두 삭제되게 구현

### 📸 스크린샷(선택)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
