### PR TITLE
[Fix/#30] : 마이페이지 유저 정보 조회에 유저 퀴즈 개수 응답에 추가

### DIFF
--- a/src/main/java/com/example/newquiz/dto/converter/UserConverter.java
+++ b/src/main/java/com/example/newquiz/dto/converter/UserConverter.java
@@ -19,10 +19,11 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponse.MyPageDto toMyPageDto(User user, int learningDays) {
+    public static UserResponse.MyPageDto toMyPageDto(User user, int learningDays, int userQuizCount) {
         return UserResponse.MyPageDto.builder()
                 .nickname(user.getNickName())
                 .maxLearningDays(user.getMaxLearningDays())
+                .userQuizCount(userQuizCount)
                 .learningDays(learningDays)
                 .avgScore(user.getAvgScore())
                 .maxAvgScore(user.getMaxAvgScore())

--- a/src/main/java/com/example/newquiz/dto/response/UserResponse.java
+++ b/src/main/java/com/example/newquiz/dto/response/UserResponse.java
@@ -42,6 +42,7 @@ public class UserResponse {
     @AllArgsConstructor
     public static class MyPageDto {
         private String nickname;
+        private Integer userQuizCount;
         private Integer maxLearningDays;
         private Integer learningDays;
         private double avgScore;

--- a/src/main/java/com/example/newquiz/repository/CompletedNewsRepository.java
+++ b/src/main/java/com/example/newquiz/repository/CompletedNewsRepository.java
@@ -2,6 +2,7 @@ package com.example.newquiz.repository;
 
 import com.example.newquiz.domain.CompletedNews;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,5 +15,7 @@ public interface CompletedNewsRepository extends JpaRepository<CompletedNews, Lo
     List<CompletedNews> findByUserIdAndIsCompletedTrueOrderByUpdatedAtDesc(Long userId);
 
     List<CompletedNews> findAllByNewsId(Long newsId);
+    @Query("SELECT COUNT(c) FROM CompletedNews c WHERE c.userId = :userId AND c.isCompleted = true")
+    int countByUserIdAndIsCompletedTrue(Long userId);
 
 }

--- a/src/main/java/com/example/newquiz/service/UserService.java
+++ b/src/main/java/com/example/newquiz/service/UserService.java
@@ -84,8 +84,9 @@ public class UserService {
 
         List<LocalDate> calendar = homeService.calculateConsecutiveLearningDays(userId);
         int learningDays = calendar == null ? 0 : homeService.calculateLearningDays(calendar.get(0), calendar.get(1));
+        int userQuizCount = completedNewsRepository.countByUserIdAndIsCompletedTrue(userId);
 
-        return UserConverter.toMyPageDto(user, learningDays);
+        return UserConverter.toMyPageDto(user, learningDays, userQuizCount);
     }
 
     // 닉네임 변경


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #30 

### 💡 작업내용
- 마이페이지 유저 정보 조회 dto 에 유저 퀴즈 개수 추가

### 📸 스크린샷(선택)
<img width="401" alt="image" src="https://github.com/user-attachments/assets/605b7de4-bde6-43b0-8d66-9fe1acb46bfe" />


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
